### PR TITLE
LRQA-47556 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Site.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Site.macro
@@ -364,9 +364,11 @@ definition {
 
 		SelectFrame(locator1 = "IFrame#DIALOG");
 
-		LexiconEntry.changeDisplayStyle(displayStyle = "cards");
+		Search.searchCP(
+			searchTerm = "${roleName}"
+		);
 
-		Check(locator1 = "Card#SPECIFIC_CHECKBOX", key_cardText = "${roleName}");
+		ManagementBar.clickSelectAllCheckbox();
 
 		SelectFrameTop();
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Site.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Site.macro
@@ -345,16 +345,22 @@ definition {
 	macro assignSiteRoleToUserGroup {
 		var key_userGroupName = "${userGroupName}";
 
-		Navigator.gotoNavItem(navItem = "User Groups");
+		Navigator.gotoNavItem(
+			navItem = "User Groups"
+		);
 
-		LexiconEntry.changeDisplayStyle(displayStyle = "table");
+		LexiconEntry.changeDisplayStyle(
+			displayStyle = "table"
+		);
 
 		AssertTextEquals(
 			locator1 = "UserGroups#USER_GROUP_TABLE_NAME",
 			value1 = "${userGroupName}"
 		);
 
-		Click(locator1 = "SiteMembershipsUserGroups#USER_GROUP_TABLE_ACTIONS");
+		Click(
+			locator1 = "SiteMembershipsUserGroups#USER_GROUP_TABLE_ACTIONS"
+		);
 
 		AssertClick(
 			locator1 = "MenuItem#ANY_MENU_ITEM",
@@ -362,7 +368,9 @@ definition {
 			key_menuItem = "Assign Site Roles"
 		);
 
-		SelectFrame(locator1 = "IFrame#DIALOG");
+		SelectFrame(
+			locator1 = "IFrame#DIALOG"
+		);
 
 		Search.searchCP(
 			searchTerm = "${roleName}"

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Card.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Card.path
@@ -14,11 +14,6 @@
 	<td></td>
 </tr>
 <tr>
-	<td>SPECIFIC_CHECKBOX</td>
-	<td>//*[@data-qa-id='row'][div[contains(@class,'card')]//*[normalize-space()='${key_cardText}']]//input[@type='checkbox']</td>
-	<td></td>
-</tr>
-<tr>
 	<td>SPECIFIC_LARGE_TEXT</td>
 	<td>//*[@data-qa-id='row'][div[contains(@class,'card')]//*[normalize-space()='${key_cardText}']]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/security/SAML.testcase
@@ -20,7 +20,9 @@ definition {
 	test AddUserInheritedRolesAsSAMLAttributeStatements {
 		property test.name.skip.portal.instance = "SAML#AddUserInheritedRolesAsSAMLAttributeStatements";
 
-		SAML.configureLiferaySAMLAsIdP(samlEntityID = "samlidp");
+		SAML.configureLiferaySAMLAsIdP(
+			samlEntityID = "samlidp"
+		);
 
 		SAML.configureLiferaySAMLAsSP(
 			attributes = "siteRoles",
@@ -41,7 +43,10 @@ definition {
 			categoryPriority = "DEBUG"
 		);
 
-		JSONRole.addSiteRole(roleKey = "TestSiteRole", roleTitle = "TestSiteRole");
+		JSONRole.addSiteRole(
+			roleKey = "TestSiteRole",
+			roleTitle = "TestSiteRole"
+		);
 
 		Navigator.openURL();
 
@@ -51,7 +56,9 @@ definition {
 			portlet = "Sites"
 		);
 
-		Site.addBlankCP(siteName = "Site Name");
+		Site.addBlankCP(
+			siteName = "Site Name"
+		);
 
 		Navigator.openURL();
 
@@ -61,11 +68,15 @@ definition {
 			portlet = "User Groups"
 		);
 
-		UserGroup.addCP(userGroupName = "UG UserGroup Name");
+		UserGroup.addCP(
+			userGroupName = "UG UserGroup Name"
+		);
 
 		Navigator.openURL();
 
-		ProductMenu.gotoSite(site = "Site Name");
+		ProductMenu.gotoSite(
+			site = "Site Name"
+		);
 
 		ProductMenu.gotoPortlet(
 			category = "People",
@@ -80,7 +91,9 @@ definition {
 
 		Navigator.openURL();
 
-		ProductMenu.gotoSite(site = "Site Name");
+		ProductMenu.gotoSite(
+			site = "Site Name"
+		);
 
 		ProductMenu.gotoPortlet(
 			category = "People",
@@ -114,7 +127,9 @@ definition {
 			portlet = "Users and Organizations"
 		);
 
-		User.gotoEditCP(userScreenName = "test");
+		User.gotoEditCP(
+			userScreenName = "test"
+		);
 
 		User.viewUserInfomationRolesCP(
 			roleTitle = "TestSiteRole",
@@ -125,7 +140,9 @@ definition {
 
 		User.viewLoggedOutPG();
 
-		User.logoutPG(specificURL = "http://www.able.com:9080/");
+		User.logoutPG(
+			specificURL = "http://www.able.com:9080/"
+		);
 
 		User.viewLoggedOutPG();
 
@@ -135,9 +152,13 @@ definition {
 			userEmailAddress = "test@liferay.com"
 		);
 
-		User.viewLoggedInPG(userFirstName = "Test");
+		User.viewLoggedInPG(
+			userFirstName = "Test"
+		);
 
-		AssertConsoleTextPresent(value1 = "TestSiteRole");
+		AssertConsoleTextPresent(
+			value1 = "TestSiteRole"
+		);
 	}
 
 	@priority = "4"


### PR DESCRIPTION
https://issues.liferay.com/browse/LRQA-47556

The old locator no longer works due to changes in cards. From inspecting the checkbox, there isn't an easy way to distinguish it from other checkboxes. The div element uses an id attribute made up of four letters that appear to be randomly generated: "gpjk" for example. The input element identifies the card by a value attribute made up of a string of numbers: "37150" for example. There doesn't seem to be a way to find this value in portal, so I simply searched for the site role instead. 

Testing performed here: https://github.com/timpak/liferay-portal-ee/pull/8

CC @xbrianlee