### PR TITLE
LPS-113217 portal-search-learning-to-rank: Set Restart-Required to false

### DIFF
--- a/modules/dxp/apps/portal-search-learning-to-rank/app.bnd
+++ b/modules/dxp/apps/portal-search-learning-to-rank/app.bnd
@@ -9,7 +9,7 @@ Liferay-Releng-Labs: false
 Liferay-Releng-Marketplace: true
 Liferay-Releng-Portal-Required: false
 Liferay-Releng-Public: ${liferay.releng.public}
-Liferay-Releng-Restart-Required: true
+Liferay-Releng-Restart-Required: false
 Liferay-Releng-Suite:
 Liferay-Releng-Support-Url: http://www.liferay.com
 Liferay-Releng-Supported: ${liferay.releng.supported}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-113217

This property was inadvertently set to true possibly by an auto SF. We already have a Poshi test that tests hot deploying this app so SF shouldn't complain.