### PR TITLE
Elasticsearch 7.11.0 Compatibility Testing | master

### DIFF
--- a/build-test-batch.xml
+++ b/build-test-batch.xml
@@ -941,6 +941,27 @@ mariadb.executable=${mariadb.executable}]]></echo>
 		</sequential>
 	</macrodef>
 
+	<macrodef name="prepare-suite-search-engine">
+		<sequential>
+			<propertycopy from="search.engine[${env.CI_TEST_SUITE}]" name="suite.search.engine" silent="true" />
+
+			<if>
+				<equals arg1="${suite.search.engine}" arg2="remote-elasticsearch7" />
+				<then>
+					<ant antfile="build-test-elasticsearch7.xml" target="start-elasticsearch" />
+				</then>
+				<elseif>
+					<equals arg1="${suite.search.engine}" arg2="remote-elasticsearch7-jdk11" />
+					<then>
+						<ant antfile="build-test-elasticsearch7.xml" target="start-elasticsearch">
+							<property name="jdk.version" value="openjdk11" />
+						</ant>
+					</then>
+				</elseif>
+			</if>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="prepare-test-build">
 		<sequential>
 			<trycatch property="exception.message">
@@ -2938,10 +2959,16 @@ log.sanitizer.enabled=false</echo>
 						</else>
 					</if>
 
+					<prepare-suite-search-engine />
+
 					<antcall inheritAll="false" target="record-test-class-file-names">
 						<param name="test.class.groups.size" value="${test.batch.size}" />
 					</antcall>
 				</test-set-up>
+
+				<test-tear-down>
+					<stop-suite-search-engine />
+				</test-tear-down>
 			</run-batch-test>
 		</sequential>
 	</macrodef>
@@ -3404,6 +3431,20 @@ log.sanitizer.enabled=false</echo>
 							CATALINA_OPTS="${CATALINA_OPTS} ${print.final.flags}"
 						]]>
 					</echo>
+				</then>
+			</if>
+		</sequential>
+	</macrodef>
+
+	<macrodef name="stop-suite-search-engine">
+		<sequential>
+			<if>
+				<or>
+					<equals arg1="${suite.search.engine}" arg2="remote-elasticsearch7" />
+					<equals arg1="${suite.search.engine}" arg2="remote-elasticsearch7-jdk11" />
+				</or>
+				<then>
+					<ant antfile="build-test-elasticsearch7.xml" target="stop-elasticsearch" />
 				</then>
 			</if>
 		</sequential>

--- a/build-test-elasticsearch7.xml
+++ b/build-test-elasticsearch7.xml
@@ -492,9 +492,8 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 					<available file="${elasticsearch.dir}/${elasticsearch.analysis-icu.zip.name}" />
 				</not>
 				<then>
-					<mirrors-get
+					<get
 						dest="${elasticsearch.dir}/${elasticsearch.analysis-icu.zip.name}"
-						skipChecksum="true"
 						src="${elasticsearch.analysis-icu.zip.url}"
 					/>
 				</then>
@@ -505,9 +504,8 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 					<available file="${elasticsearch.dir}/${elasticsearch.analysis-kuromoji.zip.name}" />
 				</not>
 				<then>
-					<mirrors-get
+					<get
 						dest="${elasticsearch.dir}/${elasticsearch.analysis-kuromoji.zip.name}"
-						skipChecksum="true"
 						src="${elasticsearch.analysis-kuromoji.zip.url}"
 					/>
 				</then>
@@ -518,9 +516,8 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 					<available file="${elasticsearch.dir}/${elasticsearch.analysis-smartcn.zip.name}" />
 				</not>
 				<then>
-					<mirrors-get
+					<get
 						dest="${elasticsearch.dir}/${elasticsearch.analysis-smartcn.zip.name}"
-						skipChecksum="true"
 						src="${elasticsearch.analysis-smartcn.zip.url}"
 					/>
 				</then>
@@ -531,9 +528,8 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 					<available file="${elasticsearch.dir}/${elasticsearch.analysis-stempel.zip.name}" />
 				</not>
 				<then>
-					<mirrors-get
+					<get
 						dest="${elasticsearch.dir}/${elasticsearch.analysis-stempel.zip.name}"
-						skipChecksum="true"
 						src="${elasticsearch.analysis-stempel.zip.url}"
 					/>
 				</then>
@@ -869,9 +865,8 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 							<available file="${app.server.parent.dir}/${elasticsearch.tar.name.mac}" />
 						</not>
 						<then>
-							<mirrors-get
+							<get
 								dest="${app.server.parent.dir}/${elasticsearch.tar.name.mac}"
-								skipChecksum="true"
 								src="${elasticsearch.tar.url.mac}"
 							/>
 						</then>
@@ -893,9 +888,8 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 							<available file="${app.server.parent.dir}/${elasticsearch.tar.name.linux}" />
 						</not>
 						<then>
-							<mirrors-get
+							<get
 								dest="${app.server.parent.dir}/${elasticsearch.tar.name.linux}"
-								skipChecksum="true"
 								src="${elasticsearch.tar.url.linux}"
 							/>
 						</then>
@@ -917,9 +911,8 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 							<available file="${app.server.parent.dir}/${elasticsearch.zip.name.windows}" />
 						</not>
 						<then>
-							<mirrors-get
+							<get
 								dest="${app.server.parent.dir}/${elasticsearch.zip.name.windows}"
-								skipChecksum="true"
 								src="${elasticsearch.zip.url.windows}"
 							/>
 						</then>
@@ -956,9 +949,8 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 							<available file="${app.server.parent.dir}/${elastic.kibana.tar.name.mac}" />
 						</not>
 						<then>
-							<mirrors-get
+							<get
 								dest="${app.server.parent.dir}/${elastic.kibana.tar.name.mac}"
-								skipChecksum="true"
 								src="${elastic.kibana.tar.url.mac}"
 							/>
 						</then>
@@ -984,9 +976,8 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 							<available file="${app.server.parent.dir}/${elastic.kibana.tar.name.linux}" />
 						</not>
 						<then>
-							<mirrors-get
+							<get
 								dest="${app.server.parent.dir}/${elastic.kibana.tar.name.linux}"
-								skipChecksum="true"
 								src="${elastic.kibana.tar.url.linux}"
 							/>
 						</then>
@@ -1013,9 +1004,8 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 							<available file="${app.server.parent.dir}/${elastic.kibana.zip.name}" />
 						</not>
 						<then>
-							<mirrors-get
+							<get
 								dest="${app.server.parent.dir}/${elastic.kibana.zip.name.windows}"
-								skipChecksum="true"
 								src="${elastic.kibana.zip.url.windows}"
 							/>
 						</then>

--- a/build-test-elasticsearch7.xml
+++ b/build-test-elasticsearch7.xml
@@ -597,9 +597,29 @@ ${line.separator}CATALINA_OPTS="${CATALINA_OPTS} -Djavax.net.ssl.trustStore=${el
 		</sequential>
 	</macrodef>
 
+	<macrodef name="set-jdk">
+		<attribute name="jdk.version" />
+
+		<sequential>
+			<if>
+				<equals arg1="@{jdk.version}" arg2="openjdk11" />
+				<then>
+					<replace
+						file="${elasticsearch.dir}/bin/elasticsearch-env"
+					>
+						<replacetoken><![CDATA[JAVA="$JAVA_HOME/bin/java"]]></replacetoken>
+						<replacevalue><![CDATA[JAVA="/opt/java/jdk11/bin/java"]]></replacevalue>
+					</replace>
+				</then>
+			</if>
+		</sequential>
+	</macrodef>
+
 	<macrodef name="set-up-standard-elasticsearch">
 		<sequential>
 			<unzip-elasticsearch />
+
+			<set-jdk jdk.version="${jdk.version}" />
 
 			<prepare-elasticsearch-analyzers />
 

--- a/build-test.xml
+++ b/build-test.xml
@@ -4469,12 +4469,24 @@ go</echo>
 	<macrodef name="set-up-search-engine">
 		<sequential>
 			<get-testcase-property property.name="remote.elasticsearch.enabled" />
+			<propertycopy from="search.engine[${env.CI_TEST_SUITE}]" name="suite.search.engine" silent="true" />
 
 			<if>
-				<equals arg1="${remote.elasticsearch.enabled}" arg2="true" />
+				<equals arg1="${suite.search.engine}" arg2="remote-elasticsearch7-jdk11" />
 				<then>
-					<ant antfile="build-test-elasticsearch7.xml" target="start-elasticsearch" />
+					<ant antfile="build-test-elasticsearch7.xml" target="start-elasticsearch">
+						<property name="jdk.version" value="openjdk11" />
+					</ant>
 				</then>
+				<elseif>
+					<or>
+						<equals arg1="${remote.elasticsearch.enabled}" arg2="true" />
+						<equals arg1="${suite.search.engine}" arg2="remote-elasticsearch7" />
+					</or>
+					<then>
+						<ant antfile="build-test-elasticsearch7.xml" target="start-elasticsearch" />
+					</then>
+				</elseif>
 			</if>
 
 			<get-testcase-property property.name="delete.sidecar.bundle" />
@@ -5750,9 +5762,13 @@ org.apache.catalina.startup.ClassLoaderFactory.level=INFO]]>
 	<macrodef name="stop-remote-search-engine">
 		<sequential>
 			<get-testcase-property property.name="remote.elasticsearch.enabled" />
+			<propertycopy from="search.engine[${env.CI_TEST_SUITE}]" name="suite.search.engine" silent="true" />
 
 			<if>
-				<istrue value="${remote.elasticsearch.enabled}" />
+				<or>
+					<equals arg1="${suite.search.engine}" arg2="remote-elasticsearch7" />
+					<istrue value="${remote.elasticsearch.enabled}" />
+				</or>
 				<then>
 					<get-testcase-property property.name="elasticsearch.cluster.size" />
 					<get-testcase-property property.name="elasticsearch.multiple.connections" />

--- a/ci.properties
+++ b/ci.properties
@@ -84,6 +84,8 @@ ci.test.available.suites=\
     saml,\
     search,\
     search-jdk11,\
+    search-remote,\
+    search-remote-jdk11,\
     security,\
     seo,\
     sf,\

--- a/ci.properties
+++ b/ci.properties
@@ -26,6 +26,7 @@ ci.test.available.suites=\
     calendar,\
     clustering,\
     commerce,\
+    commerce-remote,\
     content-page-review,\
     data-engine,\
     depot,\
@@ -108,7 +109,8 @@ ci.test.available.suites=\
     usm-upgrade,\
     vulcan-acceptance,\
     wiki,\
-    workflow
+    workflow,\
+    workflow-remote
 
 ci.test.suite.description[acceptance]=Test acceptance tests.
 ci.test.suite.description[acceptance-upstream]=Test acceptance upstream tests.

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/search/elasticsearch/Elasticsearch7.testcase
@@ -29,6 +29,7 @@ definition {
 
 	@priority = "4"
 	test AssertIndexOnStartup {
+		property embedded.elasticsearch.only = "true";
 		property test.assert.warning.exceptions = "true";
 		property test.name.skip.portal.instance = "Elasticsearch7#AssertIndexOnStartup";
 
@@ -231,6 +232,7 @@ definition {
 
 	test AssertSidecarAutoInstall {
 		property delete.sidecar.bundle = "true";
+		property embedded.elasticsearch.only = "true";
 		property environment.acceptance = "true";
 		property portal.acceptance = "true";
 		property test.assert.warning.exceptions = "true";
@@ -252,6 +254,7 @@ definition {
 	test AssertSidecarDoesNotCluster {
 		property app.server.bundles.size = "1";
 		property cluster.enabled = "true";
+		property embedded.elasticsearch.only = "true";
 		property test.assert.warning.exceptions = "true";
 		property test.name.skip.portal.instance = "Elasticsearch7#AssertSidecarDoesNotCluster";
 
@@ -511,6 +514,7 @@ definition {
 
 	@priority = "5"
 	test OSGiConfigSmokeTest {
+		property embedded.elasticsearch.only = "true";
 		property osgi.module.configuration.file.names = "com.liferay.portal.search.elasticsearch7.configuration.ElasticsearchConfiguration.config";
 		property osgi.module.configurations = "clusterName=&quot;LiferayElasticsearchCluster1&quot;";
 		property portal.acceptance = "true";
@@ -521,6 +525,7 @@ definition {
 	}
 
 	test SearchWithNonLiferayIndex {
+		property embedded.elasticsearch.only = "true";
 		property test.name.skip.portal.instance = "Elasticsearch7#SearchWithNonLiferayIndex";
 
 		Navigator.openSpecificURL(url = "http://localhost:9201");
@@ -577,6 +582,7 @@ definition {
 	}
 
 	test SwitchSidecarToRemote {
+		property embedded.elasticsearch.only = "true";
 		property test.name.skip.portal.instance = "Elasticsearch7#SwitchSidecarToRemote";
 
 		JSONWebcontent.addWebContent(
@@ -635,6 +641,7 @@ definition {
 	@description = "This is a use case for LPS-57894."
 	@priority = "3"
 	test UpdateSystemSettingsWithoutPortalRestart {
+		property embedded.elasticsearch.only = "true";
 		property test.name.skip.portal.instance = "Elasticsearch7#UpdateSystemSettingsWithoutPortalRestart";
 
 		JSONWebcontent.addWebContent(

--- a/test.properties
+++ b/test.properties
@@ -628,7 +628,7 @@
     elastic.kibana.zip.name.windows=kibana-${elasticsearch.version}-windows-x86_64.zip
     elastic.kibana.zip.url.windows=https://artifacts.elastic.co/downloads/kibana/${elastic.kibana.zip.name.windows}
 
-    elasticsearch.version=7.9.0
+    elasticsearch.version=7.11.0
     elasticsearch.dir=${app.server.parent.dir}/elasticsearch-${elasticsearch.version}
     elasticsearch.analysis-icu.zip.name=analysis-icu-${elasticsearch.version}.zip
     elasticsearch.analysis-icu.zip.url=https://artifacts.elastic.co/downloads/elasticsearch-plugins/analysis-icu/${elasticsearch.analysis-icu.zip.name}

--- a/test.properties
+++ b/test.properties
@@ -4683,8 +4683,6 @@
     test.batch.dist.app.servers[search-remote]=tomcat
 
     test.batch.names[search-remote]=\
-        functional-tomcat90-mysql57-jdk8,\
-        functional-upgrade-tomcat90-mysql57-jdk8,\
         modules-integration-mysql57-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][search-remote]=\

--- a/test.properties
+++ b/test.properties
@@ -2639,6 +2639,25 @@
         (testray.main.component.name ~ "Commerce")
 
     #
+    # Commerce with Remote Elasticsearch 7
+    #
+
+    search.engine[commerce-remote]=remote-elasticsearch7
+
+    test.batch.class.names.includes[commerce-remote]=\
+        **/commerce/**/*Test.java
+
+    test.batch.dist.app.servers[commerce-remote]=tomcat
+
+    test.batch.names[commerce-remote]=\
+        functional-tomcat90-mysql57-jdk8,\
+        modules-integration-mysql57-jdk8
+
+    test.batch.run.property.query[functional-tomcat*-mysql*-jdk8][commerce-remote]=\
+        (portal.upstream == true) AND \
+        (testray.main.component.name ~ "Commerce")
+
+    #
     # Content Page Review
     #
 
@@ -5449,6 +5468,42 @@
         )
 
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][workflow]=\
+        (portal.upstream != quarantine) AND \
+        (\
+            (testray.main.component.name == "Upgrades Workflow")\
+        )
+
+    #
+    # Workflow with Remote Elasticsearch 7
+    #
+
+    search.engine[workflow-remote]=remote-elasticsearch7
+
+    test.batch.class.names.includes[workflow-remote]=\
+        **/portal-workflow-kaleo-forms-test/**/*Test.java,\
+        **/portal-workflow-kaleo-test/**/*Test.java,\
+        **/portal-workflow-metrics-rest-test/**/*Test.java,\
+        **/portal-workflow-metrics-test/**/*Test.java,\
+        **/portal-workflow-test/**/*Test.java,\
+        **/portal-workflow-uad-test/**/*Test.java,\
+        **/src/test/**/workflow/**/*Test.java
+
+    test.batch.dist.app.servers[workflow-remote]=tomcat
+
+    test.batch.names[workflow-remote]=\
+        functional-tomcat90-mysql57-jdk8,\
+        functional-upgrade-tomcat90-mysql57-jdk8,\
+        modules-integration-mysql57-jdk8
+
+    test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][workflow-remote]=\
+        (portal.upstream != quarantine) AND \
+        (\
+            (testray.main.component.name == "Kaleo Designer") OR \
+            (testray.main.component.name == "Kaleo Forms Admin") OR \
+            (testray.main.component.name == "Workflow")\
+        )
+
+    test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][workflow-remote]=\
         (portal.upstream != quarantine) AND \
         (\
             (testray.main.component.name == "Upgrades Workflow")\

--- a/test.properties
+++ b/test.properties
@@ -4655,7 +4655,7 @@
         (testray.main.component.name ~ "Upgrades Search")
 
     #
-    # Search with Remote Elasticsearch 7 and JDK 11
+    # Search with Elasticsearch 7 and JDK 11
     #
 
     test.batch.class.names.excludes[search-jdk11]=${test.batch.class.names.excludes[search]}
@@ -4671,6 +4671,48 @@
         ${test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][search]}
 
     test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk11_open][search-jdk11]=\
+        ${test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][search]}
+
+    #
+    # Search with Remote Elasticsearch 7
+    #
+
+    search.engine[search-remote]=remote-elasticsearch7
+    test.batch.class.names.excludes[search-remote]=${test.batch.class.names.excludes[search]}
+    test.batch.class.names.includes[modules-integration-*-jdk8][search-remote]=${test.batch.class.names.includes[modules-integration-*-jdk8][search]}
+    test.batch.dist.app.servers[search-remote]=tomcat
+
+    test.batch.names[search-remote]=\
+        functional-tomcat90-mysql57-jdk8,\
+        functional-upgrade-tomcat90-mysql57-jdk8,\
+        modules-integration-mysql57-jdk8
+
+    test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][search-remote]=\
+        ${test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][search]} AND \
+        (embedded.elasticsearch.only != "true")
+
+    test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][search-remote]=\
+        ${test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][search]}
+
+    #
+    # Search with Remote Elasticsearch 7 and JDK 11
+    #
+
+    search.engine[search-remote-jdk11]=remote-elasticsearch7-jdk11
+    test.batch.class.names.excludes[search-remote-jdk11]=${test.batch.class.names.excludes[search]}
+    test.batch.class.names.includes[modules-integration-mysql57-jdk11_open][search-remote-jdk11]=${test.batch.class.names.includes[modules-integration-*-jdk8][search]}
+    test.batch.dist.app.servers[search-remote-jdk11]=tomcat
+
+    test.batch.names[search-remote-jdk11]=\
+        functional-tomcat90-mysql57-jdk11_open,\
+        functional-upgrade-tomcat90-mysql57-jdk11_open,\
+        modules-integration-mysql57-jdk11_open
+
+    test.batch.run.property.query[functional-tomcat90-mysql57-jdk11_open][search-remote-jdk11]=\
+        ${test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][search]} AND \
+        (embedded.elasticsearch.only != "true")
+
+    test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk11_open][search-remote-jdk11]=\
         ${test.batch.run.property.query[functional-upgrade-tomcat90-mysql57-jdk8][search]}
 
     #
@@ -5460,6 +5502,7 @@
         elasticsearch.cluster.size,\
         elasticsearch.ltr.enabled,\
         elasticsearch.multiple.connections,\
+        embedded.elasticsearch.only,\
         environment.acceptance,\
         ext.plugins.includes,\
         extraapps.plugins.includes,\


### PR DESCRIPTION
Creating makeshift remote suites so we can run our tests against a remote Elasticsearch 7.11 server until our team finds a solution for bumping the sidecar version to 7.11.